### PR TITLE
Deleted (pirates) from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 flask
 tinydb
 timeago
-(pirates)


### PR DESCRIPTION
Adding (pirates) to requirements.txt broke the `pip3 install -r requirements.txt` command to install the repo dependencies